### PR TITLE
fix: 전화 시 앱 로그아웃 문제 해결

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
     </receiver>
 
     <service android:name=".RecordPromptService"
-                android:foregroundServiceType="mediaProjection"
+                android:foregroundServiceType="microphone"
                 android:exported="false" />
 
       <activity

--- a/android/app/src/main/java/com/catchapp/LoginStatusModule.kt
+++ b/android/app/src/main/java/com/catchapp/LoginStatusModule.kt
@@ -16,4 +16,9 @@ class LoginStatusModule(reactContext: ReactApplicationContext) : ReactContextBas
     fun setLoggedIn(status: Boolean) {
         prefs.edit().putBoolean("isLoggedIn", status).commit()
     }
+
+    @ReactMethod
+    fun setUserId(userId: String) {
+        prefs.edit().putString("userId", userId).commit()
+}
 }

--- a/android/app/src/main/java/com/catchapp/RecordPromptService.java
+++ b/android/app/src/main/java/com/catchapp/RecordPromptService.java
@@ -35,14 +35,6 @@ public class RecordPromptService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) { 
-        boolean isLoggedIn = getSharedPreferences("LoginStatusPrefs", MODE_PRIVATE)
-                           .getBoolean("isLoggedIn", false);
-
-        if (!isLoggedIn) {
-            Log.d("RecordPromptService", "로그인되지 않음. 서비스 종료");
-            stopSelf();
-            return START_NOT_STICKY;
-        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel channel = new NotificationChannel(
                 CHANNEL_ID,
@@ -62,10 +54,20 @@ public class RecordPromptService extends Service {
 
             startForeground(1, notification);
         }
-        showFloatingPrompt();
 
+        boolean isLoggedIn = getSharedPreferences("LoginStatusPrefs", MODE_PRIVATE)
+                           .getBoolean("isLoggedIn", false);
+
+        if (!isLoggedIn) {
+            Log.d("RecordPromptService", "로그인되지 않음. 서비스 종료");
+            stopSelf();
+            return START_NOT_STICKY;
+        }
+
+        showFloatingPrompt();
         return START_NOT_STICKY;
     }
+         
 
     private void showFloatingPrompt() {
         Log.d("RecordPromptService", " showFloatingPrompt() 호출됨");
@@ -138,11 +140,11 @@ public class RecordPromptService extends Service {
                         updateDialogText("보이스피싱 판별 중...");
                     });
 
-                    String userId = getSharedPreferences("UserPrefs", MODE_PRIVATE)
-                                .getString("userId", null);
+                    String userId = getSharedPreferences("LoginStatusPrefs", MODE_PRIVATE)
+                                        .getString("userId", null);
                                 
                     if (userId == null) {
-                    Log.e("RecordPromptService", "userId가 SharedPreferences에 없음!");
+                    Log.e("RecordPromptService", "userId가 SharedPreferences에 없음");
                     return;
                 }
                 

--- a/android/app/src/main/java/com/catchapp/recording/RecordingFileObserver.java
+++ b/android/app/src/main/java/com/catchapp/recording/RecordingFileObserver.java
@@ -23,7 +23,7 @@ public class RecordingFileObserver extends FileObserver {
             File newFile = new File(directory, fileName);
             Log.d(TAG, "녹음 파일 감지됨: " + newFile.getAbsolutePath());
 
-            SharedPreferences prefs = context.getSharedPreferences("UserPrefs", Context.MODE_PRIVATE);
+            SharedPreferences prefs = context.getSharedPreferences("LoginStatusPrefs", Context.MODE_PRIVATE);
             String userId = prefs.getString("userId", null);
 
             if (userId != null) {

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -11,6 +11,7 @@ import LoginPasswordIcon from "../assets/img/login_password_icon.png";
 const LoginScreen = ({ navigation, setIsLoggedIn }) => {
   const [formData, setFormData] = useState({ email: "", password: "" });
   const [errorMessage, setErrorMessage] = useState("");
+  const { LoginStatusModule } = NativeModules;
 
   useFocusEffect(
     useCallback(() => {
@@ -41,6 +42,10 @@ const LoginScreen = ({ navigation, setIsLoggedIn }) => {
     if (token){
       await AsyncStorage.setItem("token", token);
       await AsyncStorage.setItem("userId", email);
+
+      LoginStatusModule.setLoggedIn(true);
+      LoginStatusModule.setUserId(email);
+
       setIsLoggedIn(true);
       navigation.reset({
         index: 0,


### PR DESCRIPTION
문제 :  앱 로그인 후 전화 시 보이스피싱 검사 다이얼로그가 뜨지 않음, 전화를 끊은 후 앱 접속 시 로그아웃 됨

로그 : userId가 SharedPreferences에 없음

원인 : 로그인 시 SharedPreferences (LoginStatusModule)에 로그인 유무를 저장하는 기능만 있고, 사용자 이메일을 저장하지 않아서 발생한 문제
